### PR TITLE
[MCHECKSTYLE-357] - Allow inline configuration for reporting

### DIFF
--- a/src/it/MCHECKSTYLE-357-with-header-override/invoker.properties
+++ b/src/it/MCHECKSTYLE-357-with-header-override/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean site
+# checkstyleRules requires Maven 3+
+invoker.maven.version = 3.0+
+# checkstyle 8.15 requires java 1.8+
+invoker.java.version = 1.8+

--- a/src/it/MCHECKSTYLE-357-with-header-override/pom.xml
+++ b/src/it/MCHECKSTYLE-357-with-header-override/pom.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.basistech</groupId>
+    <artifactId>MCHECKSTYLE-357</artifactId>
+    <description>Tests that the report uses the inline configuration.</description>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>@pom.version@</version>
+                    <configuration>
+                        <checkstyleRules>
+                            <module name="Checker">
+                                <property name="charset" value="UTF-8" />
+                                <property name="severity" value="error" />
+
+                                <module name="TreeWalker">
+                                    <property name="tabWidth" value="3" />
+
+                                    <module name="RegexpSinglelineJava">
+                                        <property name="format" value="^\t*(?! \*) " />
+                                        <property name="message"
+                                            value="Indent must use tab characters" />
+                                    </module>
+
+                                    <!-- Annotations -->
+                                    <module name="AnnotationUseStyle" />
+                                    <module name="MissingDeprecated">
+                                        <property name="skipNoJavadoc" value="true" />
+                                    </module>
+                                    <module name="MissingOverride" />
+                                    <module name="PackageAnnotation" />
+
+                                    <!-- Blocks -->
+                                    <module name="EmptyCatchBlock">
+                                        <property name="exceptionVariableName"
+                                            value="expected|ignore" />
+                                    </module>
+                                    <module name="LeftCurly">
+                                        <property name="option" value="nlow" />
+                                        <property name="ignoreEnums" value="false" />
+                                    </module>
+                                    <module name="NeedBraces">
+                                        <property name="allowSingleLineStatement"
+                                            value="true" />
+                                    </module>
+                                    <module name="RightCurly" />
+
+                                    <!-- Class design -->
+                                    <module name="HideUtilityClassConstructor" />
+                                    <module name="InnerTypeLast" />
+                                    <module name="InterfaceIsType" />
+                                    <module name="OneTopLevelClass" />
+
+                                    <!-- Coding -->
+                                    <module name="CovariantEquals" />
+                                    <module name="DeclarationOrder" />
+                                    <module name="DefaultComesLast" />
+                                    <module name="EmptyStatement" />
+                                    <module name="EqualsHashCode" />
+                                    <module name="ExplicitInitialization" />
+                                    <module name="MissingSwitchDefault" />
+                                    <module name="MultipleStringLiterals">
+                                        <property name="allowedDuplicates" value="4" />
+                                    </module>
+                                    <module name="OneStatementPerLine" />
+                                    <module name="OverloadMethodsDeclarationOrder" />
+                                    <module name="PackageDeclaration" />
+                                    <module name="StringLiteralEquality" />
+                                    <module name="UnnecessaryParentheses" />
+
+                                    <!-- Imports -->
+                                    <module name="AvoidStarImport" />
+                                    <module name="CustomImportOrder">
+                                        <property name="customImportOrderRules"
+                                            value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC" />
+                                    </module>
+                                    <module name="RedundantImport" />
+                                    <module name="UnusedImports">
+                                        <property name="processJavadoc" value="false" />
+                                    </module>
+
+                                    <!-- Javadoc -->
+                                    <module name="AtclauseOrder" />
+
+                                    <!-- Misc -->
+                                    <module name="ArrayTypeStyle" />
+                                    <module name="OuterTypeFilename" />
+                                    <module name="CommentsIndentation" />
+                                    <module name="Indentation">
+                                        <property name="basicOffset" value="3" />
+                                        <property name="caseIndent" value="0" />
+                                        <property name="lineWrappingIndentation" value="6" />
+                                    </module>
+                                    <module name="TodoComment">
+                                        <property name="format" value="(TODO)|(FIXME)" />
+                                    </module>
+                                    <module name="UpperEll" />
+
+                                    <!-- Modifiers -->
+                                    <module name="ModifierOrder" />
+                                    <module name="RedundantModifier" />
+
+                                    <!-- Naming -->
+                                    <module name="ConstantName" />
+
+                                    <!-- Sizes -->
+                                    <module name="LineLength">
+                                        <property name="max" value="120" />
+                                    </module>
+                                </module>
+
+                                <module name="RegexpSingleline">
+                                    <!-- Check trailing whitespace -->
+                                    <property name="format" value="\s+$" />
+                                </module>
+
+                                <module name="NewlineAtEndOfFile">
+                                    <property name="lineSeparator" value="lf" />
+                                </module>
+                                <module name="UniqueProperties" />
+                            </module>
+                        </checkstyleRules>
+                        <checkstyleRulesHeader>
+<![CDATA[
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+]]>
+                        </checkstyleRulesHeader>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.15</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <reportSets>
+                     <reportSet>
+                         <reports>
+                             <report>checkstyle</report>
+                         </reports>
+                     </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>
+

--- a/src/it/MCHECKSTYLE-357-with-header-override/src/main/java/cat/App.java
+++ b/src/it/MCHECKSTYLE-357-with-header-override/src/main/java/cat/App.java
@@ -1,0 +1,37 @@
+package cat;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+    	Object[] bucket = new Object[12345];
+    	String y = args[0];
+    	Object x = bucket[ Math.abs(y.hashCode()) % bucket.length];
+    	System.out.println( "Hello World!"  + x);
+        x = bucket[ y.hashCode() % bucket.length];
+        System.out.println( "Hello World!"  + x);
+    }
+}

--- a/src/it/MCHECKSTYLE-357-with-header-override/verify.groovy
+++ b/src/it/MCHECKSTYLE-357-with-header-override/verify.groovy
@@ -1,0 +1,30 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+assert new File(basedir, 'target/site/checkstyle.html').exists();
+
+assert new File(basedir, 'target/checkstyle-cachefile').exists();
+assert new File(basedir, 'target/checkstyle-checker.xml').exists();
+assert new File(basedir, 'target/checkstyle-result.xml').exists();
+assert new File(basedir, 'target/checkstyle-rules.xml').exists();
+
+File rssFile = new File( basedir, 'target/site/checkstyle.rss' );
+assert rssFile.exists();
+
+return true;

--- a/src/it/MCHECKSTYLE-357/invoker.properties
+++ b/src/it/MCHECKSTYLE-357/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean site
+# checkstyleRules requires Maven 3+
+invoker.maven.version = 3.0+

--- a/src/it/MCHECKSTYLE-357/pom.xml
+++ b/src/it/MCHECKSTYLE-357/pom.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.basistech</groupId>
+    <artifactId>MCHECKSTYLE-357</artifactId>
+    <description>Tests that the report uses the inline configuration.</description>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>@pom.version@</version>
+                    <configuration>
+                        <checkstyleRules>
+                            <module name="Checker">
+                                <property name="charset" value="UTF-8" />
+                                <property name="severity" value="error" />
+
+                                <module name="TreeWalker">
+                                    <property name="tabWidth" value="3" />
+
+                                    <module name="RegexpSinglelineJava">
+                                        <property name="format" value="^\t*(?! \*) " />
+                                        <property name="message"
+                                            value="Indent must use tab characters" />
+                                    </module>
+
+                                    <!-- Annotations -->
+                                    <module name="AnnotationUseStyle" />
+                                    <module name="MissingDeprecated">
+                                        <property name="skipNoJavadoc" value="true" />
+                                    </module>
+                                    <module name="MissingOverride" />
+                                    <module name="PackageAnnotation" />
+
+                                    <!-- Blocks -->
+                                    <module name="EmptyCatchBlock">
+                                        <property name="exceptionVariableName"
+                                            value="expected|ignore" />
+                                    </module>
+                                    <module name="LeftCurly">
+                                        <property name="option" value="nlow" />
+                                        <property name="ignoreEnums" value="false" />
+                                    </module>
+                                    <module name="NeedBraces">
+                                        <property name="allowSingleLineStatement"
+                                            value="true" />
+                                    </module>
+                                    <module name="RightCurly" />
+
+                                    <!-- Class design -->
+                                    <module name="HideUtilityClassConstructor" />
+                                    <module name="InnerTypeLast" />
+                                    <module name="InterfaceIsType" />
+                                    <module name="OneTopLevelClass" />
+
+                                    <!-- Coding -->
+                                    <module name="CovariantEquals" />
+                                    <module name="DeclarationOrder" />
+                                    <module name="DefaultComesLast" />
+                                    <module name="EmptyStatement" />
+                                    <module name="EqualsHashCode" />
+                                    <module name="ExplicitInitialization" />
+                                    <module name="MissingSwitchDefault" />
+                                    <module name="MultipleStringLiterals">
+                                        <property name="allowedDuplicates" value="4" />
+                                    </module>
+                                    <module name="OneStatementPerLine" />
+                                    <module name="OverloadMethodsDeclarationOrder" />
+                                    <module name="PackageDeclaration" />
+                                    <module name="StringLiteralEquality" />
+                                    <module name="UnnecessaryParentheses" />
+
+                                    <!-- Imports -->
+                                    <module name="AvoidStarImport" />
+                                    <module name="CustomImportOrder">
+                                        <property name="customImportOrderRules"
+                                            value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC" />
+                                    </module>
+                                    <module name="RedundantImport" />
+                                    <module name="UnusedImports">
+                                        <property name="processJavadoc" value="false" />
+                                    </module>
+
+                                    <!-- Javadoc -->
+                                    <module name="AtclauseOrder" />
+
+                                    <!-- Misc -->
+                                    <module name="ArrayTypeStyle" />
+                                    <module name="OuterTypeFilename" />
+                                    <module name="CommentsIndentation" />
+                                    <module name="Indentation">
+                                        <property name="basicOffset" value="3" />
+                                        <property name="caseIndent" value="0" />
+                                        <property name="lineWrappingIndentation" value="6" />
+                                    </module>
+                                    <module name="TodoComment">
+                                        <property name="format" value="(TODO)|(FIXME)" />
+                                    </module>
+                                    <module name="UpperEll" />
+
+                                    <!-- Modifiers -->
+                                    <module name="ModifierOrder" />
+                                    <module name="RedundantModifier" />
+
+                                    <!-- Naming -->
+                                    <module name="ConstantName" />
+
+                                    <!-- Sizes -->
+                                    <module name="LineLength">
+                                        <property name="max" value="120" />
+                                    </module>
+                                </module>
+
+                                <module name="RegexpSingleline">
+                                    <!-- Check trailing whitespace -->
+                                    <property name="format" value="\s+$" />
+                                </module>
+
+                                <module name="NewlineAtEndOfFile">
+                                    <property name="lineSeparator" value="lf" />
+                                </module>
+                                <module name="UniqueProperties" />
+                            </module>
+                        </checkstyleRules>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <reportSets>
+                     <reportSet>
+                         <reports>
+                             <report>checkstyle</report>
+                         </reports>
+                     </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>
+

--- a/src/it/MCHECKSTYLE-357/src/main/java/cat/App.java
+++ b/src/it/MCHECKSTYLE-357/src/main/java/cat/App.java
@@ -1,0 +1,37 @@
+package cat;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+    	Object[] bucket = new Object[12345];
+    	String y = args[0];
+    	Object x = bucket[ Math.abs(y.hashCode()) % bucket.length];
+    	System.out.println( "Hello World!"  + x);
+        x = bucket[ y.hashCode() % bucket.length];
+        System.out.println( "Hello World!"  + x);
+    }
+}

--- a/src/it/MCHECKSTYLE-357/verify.groovy
+++ b/src/it/MCHECKSTYLE-357/verify.groovy
@@ -1,0 +1,30 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+assert new File(basedir, 'target/site/checkstyle.html').exists();
+
+assert new File(basedir, 'target/checkstyle-cachefile').exists();
+assert new File(basedir, 'target/checkstyle-checker.xml').exists();
+assert new File(basedir, 'target/checkstyle-result.xml').exists();
+assert new File(basedir, 'target/checkstyle-rules.xml').exists();
+
+File rssFile = new File( basedir, 'target/site/checkstyle.rss' );
+assert rssFile.exists();
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
@@ -79,10 +79,7 @@ public class CheckstyleViolationCheckMojo
 {
 
     private static final String JAVA_FILES = "**\\/*.java";
-
-    private static final String CHECKSTYLE_FILE_HEADER = "<?xml version=\"1.0\"?>\n"
-            + "<!DOCTYPE module PUBLIC \"-//Puppy Crawl//DTD Check Configuration 1.3//EN\"\n"
-            + "        \"http://www.puppycrawl.com/dtds/configuration_1_3.dtd\">\n";
+    private static final String DEFAULT_CONFIG_LOCATION = "sun_checks.xml";
 
     /**
      * Specifies the path and filename to save the Checkstyle output. The format
@@ -198,7 +195,7 @@ public class CheckstyleViolationCheckMojo
      *
      * @since 2.5
      */
-    @Parameter( property = "checkstyle.config.location", defaultValue = "sun_checks.xml" )
+    @Parameter( property = "checkstyle.config.location", defaultValue = DEFAULT_CONFIG_LOCATION )
     private String configLocation;
 
     /**
@@ -452,6 +449,15 @@ public class CheckstyleViolationCheckMojo
     private File rulesFiles;
 
     /**
+     * The header to use for the inline configuration.
+     * Only used when you specify {@code checkstyleRules}.
+     */
+    @Parameter( defaultValue = "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE module PUBLIC \"-//Puppy Crawl//DTD Check Configuration 1.3//EN\"\n"
+            + "        \"http://www.puppycrawl.com/dtds/configuration_1_3.dtd\">\n" )
+    private String checkstyleRulesHeader;
+
+    /**
      * Specifies whether modules with a configured severity of <code>ignore</code> should be omitted during Checkstyle
      * invocation.
      * 
@@ -481,7 +487,7 @@ public class CheckstyleViolationCheckMojo
         {
             if ( checkstyleRules != null )
             {
-                if ( !"sun_checks.xml".equals( configLocation ) )
+                if ( !DEFAULT_CONFIG_LOCATION.equals( configLocation ) )
                 {
                     throw new MojoExecutionException( "If you use inline configuration for rules, don't specify "
                         + "a configLocation" );
@@ -496,7 +502,7 @@ public class CheckstyleViolationCheckMojo
                 try
                 {
                     FileUtils.forceMkdir( rulesFiles.getParentFile() );
-                    FileUtils.fileWrite( rulesFiles, CHECKSTYLE_FILE_HEADER + checkerModule.toString() );
+                    FileUtils.fileWrite( rulesFiles, checkstyleRulesHeader + checkerModule.toString() );
                 }
                 catch ( final IOException e )
                 {


### PR DESCRIPTION
As described in MCHECKSTYLE-357 this allowes the use of the inline configuration for the reports.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
