### PR TITLE
[MCHECKSTYLE-371]: Add logViolationCountToConsole option to check goal

### DIFF
--- a/src/it/MCHECKSTYLE-371/invoker.properties
+++ b/src/it/MCHECKSTYLE-371/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=verify
+# checkstyleRules requires Maven 3+
+invoker.maven.version = 3.0+

--- a/src/it/MCHECKSTYLE-371/pom.xml
+++ b/src/it/MCHECKSTYLE-371/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.checkstyle.its</groupId>
+  <artifactId>MCHECKSTYLE-371</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <url>https://issues.apache.org/jira/browse/MCHECKSTYLE-371</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <!-- some test resources are Java files and have to be properly formatted -->
+          <resourceIncludes>**\/*.java</resourceIncludes>
+
+          <checkstyleRules>
+            <module name="Checker">
+              <property name="severity" value="warning"/>
+              <!-- Checks for Size Violations. -->
+              <!-- See http://checkstyle.sf.net/config_sizes.html -->
+              <module name="FileLength">
+                <property name="max" value="10" />
+                <property name="fileExtensions" value="java" />
+              </module>
+            </module>
+          </checkstyleRules>
+          <logViolationCountToConsole>true</logViolationCountToConsole>
+          <maxAllowedViolations>10</maxAllowedViolations>
+          <violationSeverity>warning</violationSeverity>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MCHECKSTYLE-371/src/test/resources/MyClass.java
+++ b/src/it/MCHECKSTYLE-371/src/test/resources/MyClass.java
@@ -1,0 +1,27 @@
+package org;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * My class.
+ */
+public class MyClass
+{
+}

--- a/src/it/MCHECKSTYLE-371/verify.groovy
+++ b/src/it/MCHECKSTYLE-371/verify.groovy
@@ -1,0 +1,22 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def buildLog = new File( basedir, 'build.log' )
+
+assert buildLog.text.contains( "[INFO] You have 1 Checkstyle violation. The maximum number of allowed violations is 10." )

--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
@@ -155,6 +155,14 @@ public class CheckstyleViolationCheckMojo
      */
     @Parameter( property = "checkstyle.console", defaultValue = "true" )
     private boolean logViolationsToConsole;
+    
+    /**
+     * Output the detected violation count to the console.
+     * 
+     * @since 3.0.1
+     */
+    @Parameter( property = "checkstyle.logViolationCount", defaultValue = "true" )
+    private boolean logViolationCountToConsole;
 
     /**
      * Specifies the location of the resources to be used for Checkstyle.
@@ -570,20 +578,28 @@ public class CheckstyleViolationCheckMojo
 
             int violations = countViolations( xpp );
 
+            String msg = "You have " + violations + " Checkstyle violation"
+                + ( ( violations > 1 || violations == 0 ) ? "s" : "" ) + ".";
             if ( violations > maxAllowedViolations )
             {
                 if ( failOnViolation )
                 {
-                    String msg =
-                        "You have " + violations + " Checkstyle violation" + ( ( violations > 1 ) ? "s" : "" ) + ".";
                     if ( maxAllowedViolations > 0 )
                     {
                         msg += " The maximum number of allowed violations is " + maxAllowedViolations + ".";
                     }
                     throw new MojoFailureException( msg );
                 }
-
+                
                 getLog().warn( "checkstyle:check violations detected but failOnViolation set to false" );
+            }
+            if ( logViolationCountToConsole )
+            {
+                if ( maxAllowedViolations > 0 )
+                {
+                  msg += " The maximum number of allowed violations is " + maxAllowedViolations + ".";
+                }
+                getLog().info( msg );
             }
         }
         catch ( IOException | XmlPullParserException e )


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/MCHECKSTYLE-371.

This adds a logViolationCountToConsole parameter to the check mojo, which causes the plugin to log the violation count to console.

 - [x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

