### PR TITLE
MCHECKSTYLE-366 Upgrade checkstyle to a more recent version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpPlgnBuild()
+asfMavenTlpPlgnBuild(jdk:['8','9','10','11','12'])

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <!-- Because Checkstyle 6.2+ requires Java 7 -->
-    <javaVersion>7</javaVersion>
+    <!-- Because Checkstyle 7+ requires Java 8 -->
+    <javaVersion>8</javaVersion>
     <maven.compiler.source>1.${javaVersion}</maven.compiler.source>
     <maven.compiler.target>1.${javaVersion}</maven.compiler.target>
     <mavenVersion>3.0</mavenVersion>
-    <checkstyleVersion>6.18</checkstyleVersion>
+    <checkstyleVersion>8.19</checkstyleVersion>
     <doxiaVersion>1.4</doxiaVersion>
     <sitePluginVersion>3.7.1</sitePluginVersion>
   </properties>

--- a/src/it/MCHECKSTYLE-129/pom.xml
+++ b/src/it/MCHECKSTYLE-129/pom.xml
@@ -57,7 +57,7 @@ under the License.
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>${checkstyleVersion}</version>
         <configuration>
-          <configLocation>http://svn.apache.org/repos/asf/maven/plugins/tags/maven-checkstyle-plugin-2.15/src/main/resources/config/sun_checks.xml</configLocation>
+          <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-8.19/src/main/resources/sun_checks.xml</configLocation>
         </configuration>
       </plugin>
     </plugins>

--- a/src/it/MCHECKSTYLE-137/checkstyle.xml
+++ b/src/it/MCHECKSTYLE-137/checkstyle.xml
@@ -20,8 +20,6 @@ under the License.
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <module name="TreeWalker">
-        <!-- Enable FileContentsHolder to allow us to in turn turn on suppression comments -->
-        <module name="FileContentsHolder"/>
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
         <module name="ConstantName"/>
@@ -89,7 +87,7 @@ under the License.
 <!-- blows up with eclipse-cs 5.6.0
         <module name="DoubleCheckedLocking"/>
 -->
-	<module name="EmptyStatement"/>	      
+	<module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
 	    <property name="tokens" value="VARIABLE_DEF"/>
@@ -98,7 +96,6 @@ under the License.
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
-        <module name="SimplifyBooleanReturn"/>
         <module name="StringLiteralEquality"/>
         <module name="NestedIfDepth">
             <property name="max" value="3"/>
@@ -117,7 +114,6 @@ under the License.
         <module name="MultipleVariableDeclarations"/>
         <module name="UnnecessaryParentheses"/>
         <module name="FinalClass"/>
-        <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
         <module name="ThrowsCount">
             <property name="max" value="5"/>
@@ -125,7 +121,7 @@ under the License.
         <module name="VisibilityModifier">
             <property name="protectedAllowed" value="true"/>
             <property name="packageAllowed" value="true"/>
-            <!-- Allow public members with 'Rule' on the end of their names to allow for 
+            <!-- Allow public members with 'Rule' on the end of their names to allow for
                  JUnit rules. Too bad we can't make this see the @nnotations.
              -->
             <property name="publicMemberPattern" value="^.*Rule$"/>
@@ -152,7 +148,6 @@ under the License.
             <property name="caseIndent" value="0"/>
         </module>
     </module>
-    <module name="SuppressionCommentFilter"/>
     <module name="FileTabCharacter">
       <property name="eachLine" value="true"/>
     </module>

--- a/src/it/MCHECKSTYLE-137/src/main/java/org/MyClass.java
+++ b/src/it/MCHECKSTYLE-137/src/main/java/org/MyClass.java
@@ -18,16 +18,13 @@ package org;
  * specific language governing permissions and limitations
  * under the License.
  */
+public class MyClass {
 
-public class MyClass
-{
     public static boolean singleCharHiragana(int v1, char v2) {
-        if (v1 != 12 || c == 'の') 
-            {
-                return true;
-            } 
-        else
-            {
-                return false;
-            }
+        if (v1 != 12 || c == 'の') {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/it/MCHECKSTYLE-169/build-tools/src/main/resources/com/company/build-tools/checkstyle.xml
+++ b/src/it/MCHECKSTYLE-169/build-tools/src/main/resources/com/company/build-tools/checkstyle.xml
@@ -27,7 +27,6 @@ under the License.
     <property name="file" value="${checkstyle.suppressions.file}"/>
   </module>
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
         <module name="LeftCurly">
           <property name="option" value="nl"/>
         </module>

--- a/src/it/MCHECKSTYLE-193/checkstyle.xml
+++ b/src/it/MCHECKSTYLE-193/checkstyle.xml
@@ -23,8 +23,6 @@ Checkstyle rules for Basis Technology.
 -->
 <module name="Checker">
     <module name="TreeWalker">
-        <!-- Enable FileContentsHolder to allow us to in turn turn on suppression comments -->
-        <module name="FileContentsHolder"/>
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
         <module name="ConstantName"/>
@@ -159,7 +157,6 @@ Checkstyle rules for Basis Technology.
     <module name="RegexpHeader">
         <property name="header" value="/* A Required Header */"/>
     </module>
-    <module name="SuppressionCommentFilter"/>
     <module name="FileTabCharacter">
       <property name="eachLine" value="true"/>
     </module>

--- a/src/it/MCHECKSTYLE-338/empty-logging-check/src/main/java/org/apache/maven/plugins/checkstyle/EmptyLoggingCheck.java
+++ b/src/it/MCHECKSTYLE-338/empty-logging-check/src/main/java/org/apache/maven/plugins/checkstyle/EmptyLoggingCheck.java
@@ -20,10 +20,13 @@ package org.apache.maven.plugins.checkstyle;
  */
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
@@ -32,12 +35,12 @@ public class EmptyLoggingCheck
 {
 
     @Override
-    protected void processFiltered( File file, List<String> lines )
+    protected void processFiltered( File file, FileText lines )
         throws CheckstyleException
     {
-        getMessageCollector().add( new LocalizedMessage( 0, 0, getMessageBundle(),
+        addMessages( new TreeSet<LocalizedMessage>( Collections.singleton( new LocalizedMessage( 0, 0, getMessageBundle(),
                                                          "EmptyLoggingCheck on file " + file.getName(), new Object[0],
-                                                         SeverityLevel.ERROR, getId(), getClass(), null ) );
+                                                         SeverityLevel.ERROR, getId(), getClass(), null ) ) ) );
     }
 
 }

--- a/src/it/multi-modules-aggregate/child-b/src/test/java/org/apache/maven/plugins/checkstyle/its/AppTest.java
+++ b/src/it/multi-modules-aggregate/child-b/src/test/java/org/apache/maven/plugins/checkstyle/its/AppTest.java
@@ -20,9 +20,7 @@ public class AppTest
         super( testName );
     }
 
-    /**
-     * @return the suite of tests being tested
-     */
+    /* missing javadoc */
     public static Test suite()
     {
         return new TestSuite( AppTest.class );

--- a/src/it/multi-modules-aggregate/maven_checks.xml
+++ b/src/it/multi-modules-aggregate/maven_checks.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<!--
+  Checkstyle configuration that checks the Maven coding conventions from:
+-->
+
+<module name="Checker">
+
+    <!-- Checks that each Java package has a Javadoc file used for commenting. -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage       -->
+    <!--module name="JavadocPackage">
+      <property name="allowLegacy" value="true"/>
+    </module-->
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <!-- module name="NewlineAtEndOfFile"/ -->
+
+    <module name="FileLength"/>
+
+    <!-- Checks for Headers                              -->
+    <!-- See http://checkstyle.sf.net/config_header.html -->
+<!--    <module name="RegexpHeader">
+      <property name="fileExtensions" value="java"/>
+      <property name="headerFile" value="${checkstyle.header.file}"/>
+    </module>
+-->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <!-- Line with trailing spaces (disabled as it's too noisy) -->
+    <!--<module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>-->
+
+    <module name="TreeWalker">
+
+        <property name="tabWidth" value="4"/>
+
+        <!-- required for SuppressWarningsFilter (and other Suppress* rules not used here) -->
+        <!-- see http://checkstyle.sourceforge.net/config_annotation.html#SuppressWarningsHolder -->
+        <module name="SuppressWarningsHolder"/>
+
+        <module name="LeftCurly">
+          <property name="option" value="nl"/>
+        </module>
+
+        <module name="RightCurly">
+          <property name="option" value="alone"/>
+        </module>
+
+        <module name="LineLength">
+          <property name="max" value="120" />
+          <property name="ignorePattern" value="@version|@see|@todo|TODO"/>
+        </module>
+
+        <module name="MemberName" />
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <module name="JavadocMethod">
+          <property name="severity" value="warning"/>
+          <property name="scope" value="protected"/>
+        </module>
+        <module name="JavadocType">
+          <property name="scope" value="protected"/>
+          <property name="allowUnknownTags" value="true" />
+        </module>
+        <module name="JavadocVariable">
+          <property name="severity" value="info"/>
+          <property name="scope" value="protected"/>
+        </module>
+
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="UnusedImports"/>
+
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
+
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForIteratorPad">
+          <property name="option" value="space"/>
+        </module>
+        <!-- module name="NoWhitespaceAfter"/ -->
+        <!-- module name="NoWhitespaceBefore"/ -->
+        <module name="OperatorWrap"/>
+        <module name="ParenPad">
+          <property name="option" value="space" />
+        </module>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <!-- module name="MethodParamPad"/ -->
+        <module name="GenericWhitespace"/>
+
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock">
+          <property name="option" value="text"/>
+        </module>
+        <module name="NeedBraces"/>
+
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <!-- module name="AvoidInlineConditionals"/ -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField">
+          <property name="severity" value="warning"/>
+          <property name="ignoreSetter" value="true"/>
+          <property name="ignoreConstructorParameter" value="true"/>
+        </module>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber">
+          <!-- some numbers are really not that magic -->
+          <property name="ignoreNumbers" value="-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 31, 32, 37, 64, 100, 128, 256, 512, 1000, 1024"/>
+        </module>
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- module name="DesignForExtension"/ -->
+        <!-- module name="FinalClass"/ -->
+        <!-- module name="HideUtilityClassConstructor"/ -->
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier">
+          <property name="protectedAllowed" value="true"/>
+          <property name="packageAllowed" value="true"/>
+        </module>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <!-- module name="ArrayTypeStyle"/ -->
+        <!-- module name="FinalParameters"/ -->
+        <!-- Let todo plugin handle this.
+        <module name="TodoComment"/>
+          -->
+        <module name="UpperEll"/>
+
+    </module>
+
+    <!-- Support @SuppressWarnings (added in Checkstyle 5.7) -->
+    <!-- see http://checkstyle.sourceforge.net/config.html#SuppressWarningsFilter -->
+    <module name="SuppressWarningsFilter"/>
+
+    <!-- Checks properties file for a duplicated properties. -->
+    <!-- See http://checkstyle.sourceforge.net/config_misc.html#UniqueProperties -->
+    <module name="UniqueProperties"/>
+
+</module>

--- a/src/it/multi-modules-aggregate/pom.xml
+++ b/src/it/multi-modules-aggregate/pom.xml
@@ -51,13 +51,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>@pom.version@</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-resources</artifactId>
-            <version>2</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -70,7 +63,8 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
-          <configLocation>config/maven_checks.xml</configLocation>
+          <!-- this is the file we had in 2.13, slightly adapted to Checkstyle 8.x -->
+          <configLocation>maven_checks.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <inherited>false</inherited>

--- a/src/it/multi-modules-aggregate/verify.groovy
+++ b/src/it/multi-modules-aggregate/verify.groovy
@@ -20,7 +20,6 @@
 
 assert new File( basedir, 'target/checkstyle-cachefile' ).exists();
 assert new File( basedir, 'target/checkstyle-checker.xml' ).exists();
-assert new File( basedir, 'target/checkstyle-header.txt' ).exists();
 assert new File( basedir, 'target/checkstyle-result.xml' ).exists();
 
 assert new File( basedir, 'target/site/checkstyle-aggregate.html' ).exists();

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleCheckerListener.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleCheckerListener.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugins.checkstyle.exec;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
@@ -42,7 +43,7 @@ public class CheckstyleCheckerListener
     extends AutomaticBean
     implements AuditListener
 {
-    private List<File> sourceDirectories;
+    private final List<File> sourceDirectories;
 
     private CheckstyleResults results;
 
@@ -109,18 +110,21 @@ public class CheckstyleCheckerListener
     }
 
     /** {@inheritDoc} */
+    @Override
     public void auditStarted( AuditEvent event )
     {
         setResults( new CheckstyleResults() );
     }
 
     /** {@inheritDoc} */
+    @Override
     public void auditFinished( AuditEvent event )
     {
         //do nothing
     }
 
     /** {@inheritDoc} */
+    @Override
     public void fileStarted( AuditEvent event )
     {
         final String fileName = StringUtils.replace( event.getFileName(), "\\", "/" );
@@ -146,6 +150,7 @@ public class CheckstyleCheckerListener
     }
 
     /** {@inheritDoc} */
+    @Override
     public void fileFinished( AuditEvent event )
     {
         getResults().setFileViolations( currentFile, events );
@@ -153,6 +158,7 @@ public class CheckstyleCheckerListener
     }
 
     /** {@inheritDoc} */
+    @Override
     public void addError( AuditEvent event )
     {
         if ( SeverityLevel.IGNORE.equals( event.getSeverityLevel() ) )
@@ -167,7 +173,15 @@ public class CheckstyleCheckerListener
     }
 
     /** {@inheritDoc} */
+    @Override
     public void addException( AuditEvent event, Throwable throwable )
+    {
+        //Do Nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void finishLocalSetup() throws CheckstyleException
     {
         //Do Nothing
     }


### PR DESCRIPTION
MCHECKSTYLE-366 Upgrade checkstyle to a more recent version
and require Java 8 as Checkstyle 7+ requires Java 8

Fix several integration tests that didn't work with new versions of checkstyle
