### PR TITLE
remove unnecessary I/O indirections

### DIFF
--- a/src/test/java/org/apache/maven/plugins/checkstyle/AbstractCheckstyleTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/AbstractCheckstyleTestCase.java
@@ -44,7 +44,7 @@ public abstract class AbstractCheckstyleTestCase extends AbstractMojoTestCase {
     private ArtifactStubFactory artifactStubFactory;
 
     /**
-     * The current project to be test.
+     * The project to test.
      */
     private MavenProject testMavenProject;
 
@@ -80,9 +80,9 @@ public abstract class AbstractCheckstyleTestCase extends AbstractMojoTestCase {
     /**
      * Get the generated report as file in the test maven project.
      *
-     * @param name the name of the report.
+     * @param name the name of the report
      * @return the generated report as file
-     * @throws IOException if the return file doesnt exist
+     * @throws IOException if the return file doesn't exist
      */
     protected File getGeneratedReport(String name) throws IOException {
         String outputDirectory = getBasedir() + "/target/test/test-harness/"

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MinMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MinMavenProjectStub.java
@@ -27,7 +27,6 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Organization;
 import org.apache.maven.model.ReportPlugin;
-import org.codehaus.plexus.PlexusTestCase;
 
 /**
  * @author Edwin Punzalan
@@ -42,25 +41,25 @@ public class MinMavenProjectStub extends CheckstyleProjectStub {
     /** {@inheritDoc} */
     public List<String> getTestClasspathElements() throws DependencyResolutionRequiredException {
         List<String> list = new ArrayList<>(getCompileClasspathElements());
-        list.add(PlexusTestCase.getBasedir() + "/target/test-classes");
+        list.add("target/test-classes");
         return list;
     }
 
     /** {@inheritDoc} */
     public List<String> getCompileSourceRoots() {
-        return Collections.singletonList(PlexusTestCase.getBasedir() + "/target/classes");
+        return Collections.singletonList("target/classes");
     }
 
     /** {@inheritDoc} */
     public List<String> getTestCompileSourceRoots() {
         List<String> list = new ArrayList<>(getCompileSourceRoots());
-        list.add(PlexusTestCase.getBasedir() + "/target/test-classes");
+        list.add("target/test-classes");
         return list;
     }
 
     /** {@inheritDoc} */
     public File getBasedir() {
-        return new File(PlexusTestCase.getBasedir());
+        return new File(".");
     }
 
     /** {@inheritDoc} */
@@ -90,7 +89,7 @@ public class MinMavenProjectStub extends CheckstyleProjectStub {
     public Build getBuild() {
         Build build = new Build();
 
-        build.setDirectory(PlexusTestCase.getBasedir() + "/target/test-harness/checkstyle/min");
+        build.setDirectory("target/test-harness/checkstyle/min");
 
         return build;
     }

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MinMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MinMavenProjectStub.java
@@ -58,11 +58,6 @@ public class MinMavenProjectStub extends CheckstyleProjectStub {
     }
 
     /** {@inheritDoc} */
-    public File getBasedir() {
-        return new File(".");
-    }
-
-    /** {@inheritDoc} */
     public List<ReportPlugin> getReportPlugins() {
         ReportPlugin jxrPlugin = new ReportPlugin();
 

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/ModuleMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/ModuleMavenProjectStub.java
@@ -27,7 +27,6 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Organization;
 import org.apache.maven.model.ReportPlugin;
-import org.codehaus.plexus.PlexusTestCase;
 
 /**
  * @author Edwin Punzalan
@@ -43,25 +42,25 @@ public class ModuleMavenProjectStub extends CheckstyleProjectStub {
     /** {@inheritDoc} */
     public List<String> getTestClasspathElements() throws DependencyResolutionRequiredException {
         List<String> list = new ArrayList<>(getCompileClasspathElements());
-        list.add(PlexusTestCase.getBasedir() + "/target/test-classes");
+        list.add("target/test-classes");
         return list;
     }
 
     /** {@inheritDoc} */
     public List<String> getCompileSourceRoots() {
-        return Collections.singletonList(PlexusTestCase.getBasedir() + "/target/classes");
+        return Collections.singletonList("target/classes");
     }
 
     /** {@inheritDoc} */
     public List<String> getTestCompileSourceRoots() {
         List<String> list = new ArrayList<>(getCompileSourceRoots());
-        list.add(PlexusTestCase.getBasedir() + "/target/test-classes");
+        list.add("target/test-classes");
         return list;
     }
 
     /** {@inheritDoc} */
     public File getBasedir() {
-        return new File(PlexusTestCase.getBasedir());
+        return new File(".");
     }
 
     /** {@inheritDoc} */
@@ -91,9 +90,9 @@ public class ModuleMavenProjectStub extends CheckstyleProjectStub {
     public Build getBuild() {
         Build build = new Build();
 
-        build.setDirectory(PlexusTestCase.getBasedir() + "/target/test-harness/checkstyle/multi");
-        build.setSourceDirectory(PlexusTestCase.getBasedir() + "/src/test/test-sources");
-        build.setTestSourceDirectory(PlexusTestCase.getBasedir() + "/src/test/java");
+        build.setDirectory("target/test-harness/checkstyle/multi");
+        build.setSourceDirectory("src/test/test-sources");
+        build.setTestSourceDirectory("src/test/java");
 
         return build;
     }

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/ModuleMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/ModuleMavenProjectStub.java
@@ -59,11 +59,6 @@ public class ModuleMavenProjectStub extends CheckstyleProjectStub {
     }
 
     /** {@inheritDoc} */
-    public File getBasedir() {
-        return new File(".");
-    }
-
-    /** {@inheritDoc} */
     public List<ReportPlugin> getReportPlugins() {
         ReportPlugin jxrPlugin = new ReportPlugin();
 

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MultiMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MultiMavenProjectStub.java
@@ -27,7 +27,6 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Organization;
 import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusTestCase;
 
 /**
  *
@@ -65,7 +64,7 @@ public class MultiMavenProjectStub extends CheckstyleProjectStub {
 
     /** {@inheritDoc} */
     public File getBasedir() {
-        return new File(PlexusTestCase.getBasedir());
+        return new File(".");
     }
 
     /** {@inheritDoc} */
@@ -95,7 +94,7 @@ public class MultiMavenProjectStub extends CheckstyleProjectStub {
     public Build getBuild() {
         Build build = new Build();
 
-        build.setDirectory(PlexusTestCase.getBasedir() + "/target/test-harness/checkstyle/multi");
+        build.setDirectory("target/test-harness/checkstyle/multi");
 
         return build;
     }

--- a/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MultiMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/stubs/MultiMavenProjectStub.java
@@ -63,11 +63,6 @@ public class MultiMavenProjectStub extends CheckstyleProjectStub {
     }
 
     /** {@inheritDoc} */
-    public File getBasedir() {
-        return new File(".");
-    }
-
-    /** {@inheritDoc} */
     public List<ReportPlugin> getReportPlugins() {
         ReportPlugin jxrPlugin = new ReportPlugin();
 


### PR DESCRIPTION
Maven conventions make PlexusTestCase.getBasedir() unnecessary. It's effectively constant.