### PR TITLE
[MCHECKSTYLE-437] clean up before test

### DIFF
--- a/src/test/java/org/apache/maven/plugins/checkstyle/CheckstyleReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/CheckstyleReportTest.java
@@ -35,8 +35,11 @@ import org.codehaus.plexus.util.FileUtils;
  */
 public class CheckstyleReportTest extends AbstractCheckstyleTestCase {
     public void testNoSource() throws Exception {
+        // clean up after earlier runs
+        File report = new File("target/test-harness/checkstyle/no-source/checkstyle.html");
+        report.delete();
         File generatedReport = generateReport("checkstyle", "no-source-plugin-config.xml");
-        assertFalse(FileUtils.fileExists(generatedReport.getAbsolutePath()));
+        assertFalse(report + " exists", generatedReport.exists());
     }
 
     public void testMinConfiguration() throws Exception {


### PR DESCRIPTION
This is necessary to let the test pass on subsequent runs without a clean.