### PR TITLE
[MCHECKSTYLE-439] Upgrade to parent 40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>39</version>
+    <version>40</version>
     <relativePath />
   </parent>
 
@@ -154,7 +154,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-component-annotations</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -337,7 +337,7 @@ under the License.
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,6 @@ under the License.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>3.5.1</version>
             <configuration>
               <goals>
                 <goal>clean</goal>


### PR DESCRIPTION
To get rid of warnings.

Also, downgrade plexus plugin from 2.1.1 to 2.1.0 as 2.1.1 is known to be broken.

---

https://issues.apache.org/jira/browse/MCHECKSTYLE-439
