### PR TITLE
[MCHECKSTYLE-408] - Ensure Checkstyle console logs are properly formatted

### DIFF
--- a/src/main/java/org/apache/maven/plugins/checkstyle/AbstractCheckstyleReport.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/AbstractCheckstyleReport.java
@@ -661,12 +661,11 @@ public abstract class AbstractCheckstyleReport extends AbstractMavenReport {
      * @return The console listener.
      * @throws MavenReportException If something goes wrong.
      */
-    protected DefaultLogger getConsoleListener() throws MavenReportException {
-        DefaultLogger consoleListener;
+    protected AuditListener getConsoleListener() throws MavenReportException {
+        AuditListener consoleListener;
 
         if (useFile == null) {
-            stringOutputStream = new ByteArrayOutputStream();
-            consoleListener = new DefaultLogger(stringOutputStream, OutputStreamOptions.NONE);
+            consoleListener = new MavenConsoleLogger(getLog());
         } else {
             OutputStream out = getOutputStream(useFile);
 

--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleAggregateReport.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleAggregateReport.java
@@ -58,7 +58,6 @@ public class CheckstyleAggregateReport extends AbstractCheckstyleReport {
                 .setSourceDirectories(getSourceDirectories())
                 .setResources(resources)
                 .setTestResources(testResources)
-                .setStringOutputStream(stringOutputStream)
                 .setSuppressionsLocation(suppressionsLocation)
                 .setTestSourceDirectories(getTestSourceDirectories())
                 .setPropertyExpansion(propertyExpansion)

--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleReport.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleReport.java
@@ -58,7 +58,6 @@ public class CheckstyleReport extends AbstractCheckstyleReport {
                 .setSourceDirectories(getSourceDirectories())
                 .setResources(resources)
                 .setTestResources(testResources)
-                .setStringOutputStream(stringOutputStream)
                 .setSuppressionsLocation(suppressionsLocation)
                 .setTestSourceDirectories(getTestSourceDirectories())
                 .setPropertyExpansion(propertyExpansion)

--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
@@ -19,7 +19,6 @@
 package org.apache.maven.plugins.checkstyle;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -486,7 +485,7 @@ public class CheckstyleViolationCheckMojo extends AbstractMojo {
     @Parameter(property = "checkstyle.excludeGeneratedSources", defaultValue = "false")
     private boolean excludeGeneratedSources;
 
-    private ByteArrayOutputStream stringOutputStream;
+    private AuditListener auditListener;
 
     private File outputXmlFile;
 
@@ -541,7 +540,6 @@ public class CheckstyleViolationCheckMojo extends AbstractMojo {
                         .setSourceDirectories(getSourceDirectories())
                         .setResources(resources)
                         .setTestResources(testResources)
-                        .setStringOutputStream(stringOutputStream)
                         .setSuppressionsLocation(suppressionsLocation)
                         .setTestSourceDirectories(getTestSourceDirectories())
                         .setConfigLocation(effectiveConfigLocation)
@@ -747,12 +745,11 @@ public class CheckstyleViolationCheckMojo extends AbstractMojo {
         return false;
     }
 
-    private DefaultLogger getConsoleListener() throws MojoExecutionException {
-        DefaultLogger consoleListener;
+    private AuditListener getConsoleListener() throws MojoExecutionException {
+        AuditListener consoleListener;
 
         if (useFile == null) {
-            stringOutputStream = new ByteArrayOutputStream();
-            consoleListener = new DefaultLogger(stringOutputStream, OutputStreamOptions.NONE);
+            consoleListener = new MavenConsoleLogger(getLog());
         } else {
             OutputStream out = getOutputStream(useFile);
 

--- a/src/main/java/org/apache/maven/plugins/checkstyle/MavenConsoleLogger.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/MavenConsoleLogger.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.checkstyle;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Consumer;
+
+import com.puppycrawl.tools.checkstyle.DefaultLogger;
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AuditListener;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean.OutputStreamOptions;
+import org.apache.maven.plugin.logging.Log;
+
+/** An implementation of {@link AuditListener} that redirects output to the specified {@code log} */
+public class MavenConsoleLogger implements AuditListener {
+    private final Log log;
+
+    public MavenConsoleLogger(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public void auditStarted(AuditEvent event) {
+        recordMessage(delegate -> delegate.auditStarted(event));
+    }
+
+    @Override
+    public void auditFinished(AuditEvent event) {
+        recordMessage(delegate -> delegate.auditFinished(event));
+    }
+
+    @Override
+    public void fileStarted(AuditEvent event) {
+        recordMessage(delegate -> delegate.fileStarted(event));
+    }
+
+    @Override
+    public void fileFinished(AuditEvent event) {
+        recordMessage(delegate -> delegate.fileFinished(event));
+    }
+
+    @Override
+    public void addError(AuditEvent event) {
+        recordMessage(delegate -> delegate.addError(event));
+    }
+
+    @Override
+    public void addException(AuditEvent event, Throwable throwable) {
+        recordMessage(delegate -> delegate.addException(event, throwable));
+    }
+
+    private void recordMessage(Consumer<AuditListener> consumer) {
+        if (log.isInfoEnabled()) {
+            // Uses DefaultLogger for consistency
+            // Not possible to access formatting directly, so instead log out to a buffer and read that back in
+            try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+                consumer.accept(new DefaultLogger(stream, OutputStreamOptions.NONE));
+
+                if (stream.size() != 0) {
+                    log.info(stream.toString().trim());
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleExecutorRequest.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleExecutorRequest.java
@@ -18,12 +18,10 @@
  */
 package org.apache.maven.plugins.checkstyle.exec;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
 
-import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Resource;
@@ -80,9 +78,7 @@ public class CheckstyleExecutorRequest {
 
     private boolean consoleOutput;
 
-    private DefaultLogger defaultLogger;
-
-    private ByteArrayOutputStream stringOutputStream;
+    private AuditListener auditListener;
 
     private String propertiesLocation;
 
@@ -263,22 +259,13 @@ public class CheckstyleExecutorRequest {
         return this;
     }
 
-    public CheckstyleExecutorRequest setConsoleListener(DefaultLogger defaultLogger) {
-        this.defaultLogger = defaultLogger;
+    public CheckstyleExecutorRequest setConsoleListener(AuditListener auditListener) {
+        this.auditListener = auditListener;
         return this;
     }
 
-    public DefaultLogger getConsoleListener() {
-        return this.defaultLogger;
-    }
-
-    public ByteArrayOutputStream getStringOutputStream() {
-        return stringOutputStream;
-    }
-
-    public CheckstyleExecutorRequest setStringOutputStream(ByteArrayOutputStream stringOutputStream) {
-        this.stringOutputStream = stringOutputStream;
-        return this;
+    public AuditListener getConsoleListener() {
+        return this.auditListener;
     }
 
     public String getConfigLocation() {

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -183,14 +183,6 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
 
         checker.destroy();
 
-        if (request.getStringOutputStream() != null) {
-            String message = request.getStringOutputStream().toString().trim();
-
-            if (message.length() > 0) {
-                getLogger().info(message);
-            }
-        }
-
         if (nbErrors > 0) {
             StringBuilder message = new StringBuilder("There ");
             if (nbErrors == 1) {


### PR DESCRIPTION
When the `check` goal is run, the following is output:
```bash
[INFO] --- checkstyle:check (default-cli) @ project ---
[INFO] Starting audit...
Audit done.
```

At first glance, it _appears_ as the `Audit done` message is not from a logger, and this was how the issue was described in [MCHECKSTYLE-408](https://issues.apache.org/jira/browse/MCHECKSTYLE-408).

Further investigation shows that actually, all logging events are written to `stringOutputStream`, resulting in this:
> Starting audit...
Audit done.

And at the end, this is logged as a single, multi-line log message.

Changes:
- Replace `stringOutputStream`/`defaultLogger` with a new data structure (`CheckstyleExecutorRequest`)
- Log the messages _as they are produced_, rather than in a batch at the end

New output:
```bash
[INFO] --- checkstyle:check (default-cli) @ project ---
[INFO] Starting audit...
[INFO] Audit done.
```


 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
