### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/src/config/checkstyle-suppressions.xml
+++ b/src/config/checkstyle-suppressions.xml
@@ -22,5 +22,5 @@ under the License.
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
  <suppressions>
   <suppress checks="ParameterNumberCheck" files="CheckstyleReportRenderer.java" />
-  <suppress checks="MethodLengthCheck" files="DefaultCheckstyleExecutor.java" />
+  <suppress checks="ConstantName|MethodLengthCheck" files="DefaultCheckstyleExecutor.java" />
 </suppressions>

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -52,8 +52,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.FileResourceCreationException;
 import org.codehaus.plexus.resource.loader.FileResourceLoader;
@@ -69,7 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 @Named
 @Typed(CheckstyleExecutor.class)
-public class DefaultCheckstyleExecutor  implements CheckstyleExecutor {
+public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
 

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -70,9 +70,10 @@ import org.slf4j.LoggerFactory;
 @Named
 @Typed(CheckstyleExecutor.class)
 public class DefaultCheckstyleExecutor  implements CheckstyleExecutor {
+
     private static final Logger logger = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
 
-  private final ResourceManager locator;
+    private final ResourceManager locator;
 
     private final ResourceManager licenseLocator;
 

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -66,7 +66,8 @@ import org.slf4j.LoggerFactory;
  */
 @Component(role = CheckstyleExecutor.class, hint = "default", instantiationStrategy = "per-lookup")
 public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
-    private static final Logger logger = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
+
     @Requirement(hint = "default")
     private ResourceManager locator;
 
@@ -75,8 +76,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
     public CheckstyleResults executeCheckstyle(CheckstyleExecutorRequest request)
             throws CheckstyleExecutorException, CheckstyleException {
-        if (logger.isDebugEnabled()) {
-            logger.debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
         }
 
         MavenProject project = request.getProject();
@@ -214,7 +215,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                 // work regardless of config), but should record this information
                 throw new CheckstyleExecutorException(message.toString());
             } else {
-                logger.info(message.toString());
+                LOGGER.info(message.toString());
             }
         }
 
@@ -249,7 +250,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     File resourcesDirectory = new File(resource.getDirectory());
                     if (resourcesDirectory.exists() && resourcesDirectory.isDirectory()) {
                         sinkListener.addSourceDirectory(resourcesDirectory);
-                        logger.debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
+                        LOGGER.debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
                     }
                 }
             }
@@ -278,8 +279,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     : System.getProperty("file.encoding", "UTF-8");
 
             if (StringUtils.isEmpty(request.getEncoding())) {
-                logger.warn("File encoding has not been set, using platform encoding " + effectiveEncoding
-                                + ", i.e. build is platform dependent!");
+                LOGGER.warn("File encoding has not been set, using platform encoding " + effectiveEncoding
+                        + ", i.e. build is platform dependent!");
             }
 
             if ("Checker".equals(config.getName())
@@ -289,7 +290,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     addAttributeIfNotExists((DefaultConfiguration) config, "charset", effectiveEncoding);
                     addAttributeIfNotExists((DefaultConfiguration) config, "cacheFile", request.getCacheFile());
                 } else {
-                    logger.warn("Failed to configure file encoding on module " + config);
+                    LOGGER.warn("Failed to configure file encoding on module " + config);
                 }
             }
             return config;
@@ -359,8 +360,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
         Properties p = new Properties();
         try {
             if (request.getPropertiesLocation() != null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
                 }
 
                 File propertiesFile =
@@ -390,8 +391,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     headerLocation = "config/maven-header.txt";
                 }
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("headerLocation " + headerLocation);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("headerLocation " + headerLocation);
             }
 
             if (headerLocation != null && !headerLocation.isEmpty()) {
@@ -402,8 +403,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                         p.setProperty("checkstyle.header.file", headerFile.getAbsolutePath());
                     }
                 } catch (FileResourceCreationException | ResourceNotFoundException e) {
-                    logger.debug("Unable to process header location: " + headerLocation);
-                    logger.debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
+                    LOGGER.debug("Unable to process header location: " + headerLocation);
+                    LOGGER.debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
                 }
             }
 
@@ -477,7 +478,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     request.getTestSourceDirectories());
         }
 
-        logger.debug("Added " + files.size() + " files to process.");
+        LOGGER.debug("Added " + files.size() + " files to process.");
 
         return new ArrayList<>(files);
     }
@@ -496,8 +497,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     final List<File> sourceFiles =
                             FileUtils.getFiles(sourceDirectory, request.getIncludes(), request.getExcludes());
                     files.addAll(sourceFiles);
-                    logger.debug("Added " + sourceFiles.size() + " source files found in '"
-                                    + sourceDirectory.getAbsolutePath() + "'.");
+                    LOGGER.debug("Added " + sourceFiles.size() + " source files found in '"
+                            + sourceDirectory.getAbsolutePath() + "'.");
                 }
             }
         }
@@ -509,8 +510,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                             FileUtils.getFiles(testSourceDirectory, request.getIncludes(), request.getExcludes());
 
                     files.addAll(testSourceFiles);
-                    logger.debug("Added " + testSourceFiles.size() + " test source files found in '"
-                                    + testSourceDirectory.getAbsolutePath() + "'.");
+                    LOGGER.debug("Added " + testSourceFiles.size() + " test source files found in '"
+                            + testSourceDirectory.getAbsolutePath() + "'.");
                 }
             }
         }
@@ -518,13 +519,13 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
         if (resources != null && request.isIncludeResources()) {
             addResourceFilesToProcess(request, resources, files);
         } else {
-            logger.debug("No resources found in this project.");
+            LOGGER.debug("No resources found in this project.");
         }
 
         if (testResources != null && request.isIncludeTestResources()) {
             addResourceFilesToProcess(request, testResources, files);
         } else {
-            logger.debug("No test resources found in this project.");
+            LOGGER.debug("No test resources found in this project.");
         }
     }
 
@@ -558,11 +559,11 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
                     List<File> resourceFiles = FileUtils.getFiles(resourcesDirectory, includes, excludes);
                     files.addAll(resourceFiles);
-                    logger.debug("Added " + resourceFiles.size() + " resource files found in '"
-                                    + resourcesDirectory.getAbsolutePath() + "'.");
+                    LOGGER.debug("Added " + resourceFiles.size() + " resource files found in '"
+                            + resourcesDirectory.getAbsolutePath() + "'.");
                 } else {
-                    logger.debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
-                                    + "' does not exist or is not a directory.");
+                    LOGGER.debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
+                            + "' does not exist or is not a directory.");
                 }
             }
         }
@@ -600,8 +601,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
     private String getConfigFile(CheckstyleExecutorRequest request) throws CheckstyleExecutorException {
         try {
-            if (logger.isDebugEnabled()) {
-                logger.debug("request.getConfigLocation() " + request.getConfigLocation());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("request.getConfigLocation() " + request.getConfigLocation());
             }
 
             File configFile = locator.getResourceAsFile(request.getConfigLocation(), "checkstyle-checker.xml");

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  */
 @Component(role = CheckstyleExecutor.class, hint = "default", instantiationStrategy = "per-lookup")
 public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
+    private static final Logger logger = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
 
     @Requirement(hint = "default")
     private ResourceManager locator;
@@ -76,8 +76,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
     public CheckstyleResults executeCheckstyle(CheckstyleExecutorRequest request)
             throws CheckstyleExecutorException, CheckstyleException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
+        if (logger.isDebugEnabled()) {
+            logger.debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
         }
 
         MavenProject project = request.getProject();
@@ -215,7 +215,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                 // work regardless of config), but should record this information
                 throw new CheckstyleExecutorException(message.toString());
             } else {
-                LOGGER.info(message.toString());
+                logger.info(message.toString());
             }
         }
 
@@ -250,7 +250,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     File resourcesDirectory = new File(resource.getDirectory());
                     if (resourcesDirectory.exists() && resourcesDirectory.isDirectory()) {
                         sinkListener.addSourceDirectory(resourcesDirectory);
-                        LOGGER.debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
+                        logger.debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
                     }
                 }
             }
@@ -279,7 +279,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     : System.getProperty("file.encoding", "UTF-8");
 
             if (StringUtils.isEmpty(request.getEncoding())) {
-                LOGGER.warn("File encoding has not been set, using platform encoding " + effectiveEncoding
+                logger.warn("File encoding has not been set, using platform encoding " + effectiveEncoding
                         + ", i.e. build is platform dependent!");
             }
 
@@ -290,7 +290,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     addAttributeIfNotExists((DefaultConfiguration) config, "charset", effectiveEncoding);
                     addAttributeIfNotExists((DefaultConfiguration) config, "cacheFile", request.getCacheFile());
                 } else {
-                    LOGGER.warn("Failed to configure file encoding on module " + config);
+                    logger.warn("Failed to configure file encoding on module " + config);
                 }
             }
             return config;
@@ -360,8 +360,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
         Properties p = new Properties();
         try {
             if (request.getPropertiesLocation() != null) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
                 }
 
                 File propertiesFile =
@@ -391,8 +391,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     headerLocation = "config/maven-header.txt";
                 }
             }
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("headerLocation " + headerLocation);
+            if (logger.isDebugEnabled()) {
+                logger.debug("headerLocation " + headerLocation);
             }
 
             if (headerLocation != null && !headerLocation.isEmpty()) {
@@ -403,8 +403,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                         p.setProperty("checkstyle.header.file", headerFile.getAbsolutePath());
                     }
                 } catch (FileResourceCreationException | ResourceNotFoundException e) {
-                    LOGGER.debug("Unable to process header location: " + headerLocation);
-                    LOGGER.debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
+                    logger.debug("Unable to process header location: " + headerLocation);
+                    logger.debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
                 }
             }
 
@@ -478,7 +478,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     request.getTestSourceDirectories());
         }
 
-        LOGGER.debug("Added " + files.size() + " files to process.");
+        logger.debug("Added " + files.size() + " files to process.");
 
         return new ArrayList<>(files);
     }
@@ -497,7 +497,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                     final List<File> sourceFiles =
                             FileUtils.getFiles(sourceDirectory, request.getIncludes(), request.getExcludes());
                     files.addAll(sourceFiles);
-                    LOGGER.debug("Added " + sourceFiles.size() + " source files found in '"
+                    logger.debug("Added " + sourceFiles.size() + " source files found in '"
                             + sourceDirectory.getAbsolutePath() + "'.");
                 }
             }
@@ -510,7 +510,7 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
                             FileUtils.getFiles(testSourceDirectory, request.getIncludes(), request.getExcludes());
 
                     files.addAll(testSourceFiles);
-                    LOGGER.debug("Added " + testSourceFiles.size() + " test source files found in '"
+                    logger.debug("Added " + testSourceFiles.size() + " test source files found in '"
                             + testSourceDirectory.getAbsolutePath() + "'.");
                 }
             }
@@ -519,13 +519,13 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
         if (resources != null && request.isIncludeResources()) {
             addResourceFilesToProcess(request, resources, files);
         } else {
-            LOGGER.debug("No resources found in this project.");
+            logger.debug("No resources found in this project.");
         }
 
         if (testResources != null && request.isIncludeTestResources()) {
             addResourceFilesToProcess(request, testResources, files);
         } else {
-            LOGGER.debug("No test resources found in this project.");
+            logger.debug("No test resources found in this project.");
         }
     }
 
@@ -559,10 +559,10 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
                     List<File> resourceFiles = FileUtils.getFiles(resourcesDirectory, includes, excludes);
                     files.addAll(resourceFiles);
-                    LOGGER.debug("Added " + resourceFiles.size() + " resource files found in '"
+                    logger.debug("Added " + resourceFiles.size() + " resource files found in '"
                             + resourcesDirectory.getAbsolutePath() + "'.");
                 } else {
-                    LOGGER.debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
+                    logger.debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
                             + "' does not exist or is not a directory.");
                 }
             }
@@ -601,8 +601,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
     private String getConfigFile(CheckstyleExecutorRequest request) throws CheckstyleExecutorException {
         try {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("request.getConfigLocation() " + request.getConfigLocation());
+            if (logger.isDebugEnabled()) {
+                logger.debug("request.getConfigLocation() " + request.getConfigLocation());
             }
 
             File configFile = locator.getResourceAsFile(request.getConfigLocation(), "checkstyle-checker.xml");

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -51,12 +51,13 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.FileResourceCreationException;
 import org.codehaus.plexus.resource.loader.FileResourceLoader;
 import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
 import org.codehaus.plexus.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Olivier Lamy
@@ -64,7 +65,8 @@ import org.codehaus.plexus.util.FileUtils;
  *
  */
 @Component(role = CheckstyleExecutor.class, hint = "default", instantiationStrategy = "per-lookup")
-public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements CheckstyleExecutor {
+public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultCheckstyleExecutor.class);
     @Requirement(hint = "default")
     private ResourceManager locator;
 
@@ -73,8 +75,8 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
 
     public CheckstyleResults executeCheckstyle(CheckstyleExecutorRequest request)
             throws CheckstyleExecutorException, CheckstyleException {
-        if (getLogger().isDebugEnabled()) {
-            getLogger().debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
+        if (logger.isDebugEnabled()) {
+            logger.debug("executeCheckstyle start headerLocation : " + request.getHeaderLocation());
         }
 
         MavenProject project = request.getProject();
@@ -212,7 +214,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                 // work regardless of config), but should record this information
                 throw new CheckstyleExecutorException(message.toString());
             } else {
-                getLogger().info(message.toString());
+                logger.info(message.toString());
             }
         }
 
@@ -247,8 +249,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     File resourcesDirectory = new File(resource.getDirectory());
                     if (resourcesDirectory.exists() && resourcesDirectory.isDirectory()) {
                         sinkListener.addSourceDirectory(resourcesDirectory);
-                        getLogger()
-                                .debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
+                        logger.debug("Added '" + resourcesDirectory.getAbsolutePath() + "' as a source directory.");
                     }
                 }
             }
@@ -277,8 +278,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     : System.getProperty("file.encoding", "UTF-8");
 
             if (StringUtils.isEmpty(request.getEncoding())) {
-                getLogger()
-                        .warn("File encoding has not been set, using platform encoding " + effectiveEncoding
+                logger.warn("File encoding has not been set, using platform encoding " + effectiveEncoding
                                 + ", i.e. build is platform dependent!");
             }
 
@@ -289,7 +289,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     addAttributeIfNotExists((DefaultConfiguration) config, "charset", effectiveEncoding);
                     addAttributeIfNotExists((DefaultConfiguration) config, "cacheFile", request.getCacheFile());
                 } else {
-                    getLogger().warn("Failed to configure file encoding on module " + config);
+                    logger.warn("Failed to configure file encoding on module " + config);
                 }
             }
             return config;
@@ -359,8 +359,8 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
         Properties p = new Properties();
         try {
             if (request.getPropertiesLocation() != null) {
-                if (getLogger().isDebugEnabled()) {
-                    getLogger().debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("request.getPropertiesLocation() " + request.getPropertiesLocation());
                 }
 
                 File propertiesFile =
@@ -390,8 +390,8 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     headerLocation = "config/maven-header.txt";
                 }
             }
-            if (getLogger().isDebugEnabled()) {
-                getLogger().debug("headerLocation " + headerLocation);
+            if (logger.isDebugEnabled()) {
+                logger.debug("headerLocation " + headerLocation);
             }
 
             if (headerLocation != null && !headerLocation.isEmpty()) {
@@ -402,8 +402,8 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                         p.setProperty("checkstyle.header.file", headerFile.getAbsolutePath());
                     }
                 } catch (FileResourceCreationException | ResourceNotFoundException e) {
-                    getLogger().debug("Unable to process header location: " + headerLocation);
-                    getLogger().debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
+                    logger.debug("Unable to process header location: " + headerLocation);
+                    logger.debug("Checkstyle will throw exception if ${checkstyle.header.file} is used");
                 }
             }
 
@@ -477,7 +477,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     request.getTestSourceDirectories());
         }
 
-        getLogger().debug("Added " + files.size() + " files to process.");
+        logger.debug("Added " + files.size() + " files to process.");
 
         return new ArrayList<>(files);
     }
@@ -496,8 +496,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                     final List<File> sourceFiles =
                             FileUtils.getFiles(sourceDirectory, request.getIncludes(), request.getExcludes());
                     files.addAll(sourceFiles);
-                    getLogger()
-                            .debug("Added " + sourceFiles.size() + " source files found in '"
+                    logger.debug("Added " + sourceFiles.size() + " source files found in '"
                                     + sourceDirectory.getAbsolutePath() + "'.");
                 }
             }
@@ -510,8 +509,7 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
                             FileUtils.getFiles(testSourceDirectory, request.getIncludes(), request.getExcludes());
 
                     files.addAll(testSourceFiles);
-                    getLogger()
-                            .debug("Added " + testSourceFiles.size() + " test source files found in '"
+                    logger.debug("Added " + testSourceFiles.size() + " test source files found in '"
                                     + testSourceDirectory.getAbsolutePath() + "'.");
                 }
             }
@@ -520,13 +518,13 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
         if (resources != null && request.isIncludeResources()) {
             addResourceFilesToProcess(request, resources, files);
         } else {
-            getLogger().debug("No resources found in this project.");
+            logger.debug("No resources found in this project.");
         }
 
         if (testResources != null && request.isIncludeTestResources()) {
             addResourceFilesToProcess(request, testResources, files);
         } else {
-            getLogger().debug("No test resources found in this project.");
+            logger.debug("No test resources found in this project.");
         }
     }
 
@@ -560,12 +558,10 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
 
                     List<File> resourceFiles = FileUtils.getFiles(resourcesDirectory, includes, excludes);
                     files.addAll(resourceFiles);
-                    getLogger()
-                            .debug("Added " + resourceFiles.size() + " resource files found in '"
+                    logger.debug("Added " + resourceFiles.size() + " resource files found in '"
                                     + resourcesDirectory.getAbsolutePath() + "'.");
                 } else {
-                    getLogger()
-                            .debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
+                    logger.debug("The resources directory '" + resourcesDirectory.getAbsolutePath()
                                     + "' does not exist or is not a directory.");
                 }
             }
@@ -604,8 +600,8 @@ public class DefaultCheckstyleExecutor extends AbstractLogEnabled implements Che
 
     private String getConfigFile(CheckstyleExecutorRequest request) throws CheckstyleExecutorException {
         try {
-            if (getLogger().isDebugEnabled()) {
-                getLogger().debug("request.getConfigLocation() " + request.getConfigLocation());
+            if (logger.isDebugEnabled()) {
+                logger.debug("request.getConfigLocation() " + request.getConfigLocation());
             }
 
             File configFile = locator.getResourceAsFile(request.getConfigLocation(), "checkstyle-checker.xml");


### PR DESCRIPTION
As seen on https://cwiki.apache.org/confluence/plugins/servlet/mobile?contentId=181305684#MavenEcosystemCleanup-DropPlexusContainerforJSR-330+SisuGuiceextension

- Leverages https://github.com/openrewrite/rewrite-apache/pull/41

I have another two lined up for apache/maven and apache/maven-archetype that I'll verify first.

@elharo if you wouldn't mind, could you look this over?

Use this link to re-run the recipe: https://app.moderne.io/builder/P4zH7djn6?organizationId=QXBhY2hlIE1hdmVu