### PR TITLE
maven-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,12 +261,7 @@ under the License.
       <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
are we using it? signs point to yes:

[ERROR] Errors: 
[ERROR]   CheckstyleReportTest>AbstractCheckstyleTestCase.setUp:57->AbstractMojoTestCase.setUp:163->PlexusTestCase.lookup:211 » ComponentLookup java.util.NoSuchElementException
      role: org.apache.maven.repository.RepositorySystem
  roleHint: 
[ERROR]   CheckstyleReportTest>AbstractCheckstyleTestCase.setUp:57->AbstractMojoTestCase.setUp:163->PlexusTestCase.lookup:211 » ComponentLookup java.util.NoSuchElementException
