### PR TITLE
Use plugin-tool-property for plugin-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@ under the License.
     <doxiaSitetoolsVersion>2.0.0</doxiaSitetoolsVersion>
     <sitePluginVersion>3.20.0</sitePluginVersion>
     <jxrPluginVersion>3.5.0</jxrPluginVersion>
-    <mavenPluginAnnotationVersion>3.15.1</mavenPluginAnnotationVersion>
     <project.build.outputTimestamp>2024-10-22T15:04:06Z</project.build.outputTimestamp>
   </properties>
 
@@ -115,7 +114,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>${mavenPluginAnnotationVersion}</version>
+      <version>${version.maven-plugin-tools}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR changes the property used as a version for the plugin-annotations to the one defined in parent for all plugin-tools.

Follow up of #170 