### PR TITLE
fix: rename encoding to inputEncoding for useage.apt.vm

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -95,7 +95,7 @@ mvn checkstyle:checkstyle
    <version>${project.version}</version>
    <configuration>
      <configLocation>checkstyle.xml</configLocation>
-     <encoding>UTF-8</encoding>
+     <inputEncoding>UTF-8</inputEncoding>
      <consoleOutput>true</consoleOutput>
      <failsOnError>true</failsOnError>
      <linkXRef>false</linkXRef>


### PR DESCRIPTION
parameter 'encoding' is renamed to 'inputEncoding' since commit https://github.com/apache/maven-checkstyle-plugin/commit/627fa4f684866a579f2c105fcc1dbf3ed776daa8

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
