### PR TITLE
Verify the build against Maven 4 as well

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true


### PR DESCRIPTION
Adds `maven4-enabled: true`, which **appends** 4.0.0-rc-6 to the existing Maven 3 matrix rather than replacing it — so the plugin keeps being built and tested with Maven 3 and additionally gets verified against Maven 4. The shared workflow also excludes the `{jdk: 8, maven: 4.x}` cell automatically, since Maven 4 needs JDK 17+.

Part of establishing which Maven 3 plugins already build clean on Maven 4 ahead of the 4.0.0 GA. Same change as apache/maven-javadoc-plugin#1350. Context in apache/maven#12676.

If the Maven 4 cell turns out to fail, that is the useful result — better to know now than at GA.