### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/custom-checker-config.md.vm
+++ b/src/site/markdown/examples/custom-checker-config.md.vm
@@ -46,5 +46,5 @@ This example causes the Checkstyle Plugin to check for a File named `checkstyle.
 
 There are 2 predefined Checkstyle configuration definitions that ship with the Checkstyle Plugin, the Sun Microsystems Definition is selected by default.
 
-- **sun\_checks.xml** - Sun Microsystems Definition (default).
-- **google\_checks.xml** - Google Definition.
+- **sun_checks.xml** - Sun Microsystems Definition (default).
+- **google_checks.xml** - Google Definition.


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.