### PR TITLE
Stop protecting the abandoned maven-checkstyle-plugin-3.4.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,7 +32,6 @@ github:
     - MCHECKSTYLE
   protected_branches:
     master: { }
-    maven-checkstyle-plugin-3.4.x: { }
   pull_requests:
     del_branch_on_merge: true
   features:


### PR DESCRIPTION
`.asf.yaml` protects `maven-checkstyle-plugin-3.4.x`, which is the only thing keeping that branch around. It holds nothing master does not already have:

```console
$ git rev-list --count origin/master..origin/maven-checkstyle-plugin-3.4.x
0
```

The history behind that:

| | |
|---|---|
| 3.4.0 released | 2024-06-02, from a commit on both lines |
| branch cut, version set to | `3.4.1-SNAPSHOT` |
| last commit on the branch | **2024-08-19** — `Bump org.apache.maven.plugins:maven-plugins from 42 to 43` |
| **3.5.0 released from master** | **2024-08-19** — the same day |
| 3.6.0 released from master | 2024-10-22 |
| master today | `3.6.1-SNAPSHOT` |

So the line was cut for a 3.4.1 patch release that never happened, and was abandoned the day 3.5.0 shipped from master instead. Its final four commits are three Dependabot bumps and a Reproducible Central badge URL change — nothing functional ever landed on it, and both later minors came off master.

Nothing else refers to it either: no open pull request targets it, and `maven-sources`' `default.xml` pins this plugin to the default branch rather than to `-3.x`.

With the entry dropped, `git push origin --delete maven-checkstyle-plugin-3.4.x` becomes possible. Leaving the branch in place but unprotected is also fine — this change only stops treating it as a maintained line.

`.asf.yaml` is read from the default branch only, so unlike a code change there is no maintenance-line counterpart to port here.

Draft until CI is green.

<sub>Drafted with Claude — please verify</sub>