### PR TITLE
Build the MCHECKSTYLE-357 IT against the current Checkstyle

### DIFF
--- a/src/it/MCHECKSTYLE-357-with-header-override/pom.xml
+++ b/src/it/MCHECKSTYLE-357-with-header-override/pom.xml
@@ -55,9 +55,7 @@
 
                                     <!-- Annotations -->
                                     <module name="AnnotationUseStyle" />
-                                    <module name="MissingDeprecated">
-                                        <property name="skipNoJavadoc" value="true" />
-                                    </module>
+                                    <module name="MissingDeprecated" />
                                     <module name="MissingOverride" />
                                     <module name="PackageAnnotation" />
 
@@ -133,11 +131,11 @@
 
                                     <!-- Naming -->
                                     <module name="ConstantName" />
+                                </module>
 
-                                    <!-- Sizes -->
-                                    <module name="LineLength">
-                                        <property name="max" value="120" />
-                                    </module>
+                                <!-- Sizes -->
+                                <module name="LineLength">
+                                    <property name="max" value="120" />
                                 </module>
 
                                 <module name="RegexpSingleline">
@@ -170,7 +168,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.15</version>
+                            <version>@checkstyleVersion@</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
The header-override variant of the MCHECKSTYLE-357 integration test pins `com.puppycrawl.tools:checkstyle` 8.15 — the version that was current when the test was added in 2018. Every other IT that needs an explicit Checkstyle dependency filters in `@checkstyleVersion@` (currently 9.3), so this one now does too.

That silences both open Dependabot alerts on this repo ([#2](https://github.com/apache/maven-checkstyle-plugin/security/dependabot/2), `< 8.18`, and [#3](https://github.com/apache/maven-checkstyle-plugin/security/dependabot/3), `< 8.29`) — same manifest, same dependency.

Two rules in the inline ruleset had to move with the upgrade, since the IT exercises `checkstyleRules`/`checkstyleRulesHeader` rather than any particular rule:

- `MissingDeprecated` lost its `skipNoJavadoc` property in Checkstyle 8.24.
- `LineLength` is a child of `Checker`, not `TreeWalker`, since 8.24.

Verified locally: `mvn -Prun-its -Dinvoker.test=MCHECKSTYLE-357-with-header-override verify` passes, the run resolves `checkstyle-9.3.jar`, and the generated `target/checkstyle-rules.xml` still carries the overridden DOCTYPE header the test is about.

Generated-by: Claude Opus 5 (1M context)