### PR TITLE
Inherit the maven-invoker-plugin version from the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@ under the License.
     <doxiaSitetoolsVersion>2.1.0</doxiaSitetoolsVersion>
     <sitePluginVersion>3.20.0</sitePluginVersion>
     <jxrPluginVersion>3.5.0</jxrPluginVersion>
-    <version.maven-invoker-plugin>3.9.1</version.maven-invoker-plugin>
     <project.build.outputTimestamp>2024-10-22T15:04:06Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
The integration tests cannot run on a JDK 26 toolchain today. Every `verify.groovy` post-build hook dies with:

```
java.lang.IllegalArgumentException: Unsupported class file major version 70
    at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:200)
    at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:83)
```

The failure mode is worse than a plain failure: the IT's own `build.log` still says `BUILD SUCCESS`, and only the post-build hook blows up — so a green run and a red one look the same until you read the stack trace.

The cause is the Groovy that maven-invoker-plugin 3.9.1 brings in, 4.0.27, whose bundled ASM cannot read JDK 26 (major version 70) class files. 3.10.1 ships Groovy 4.0.31, which can.

Rather than restate 3.10.1 locally, this drops the `version.maven-invoker-plugin` property altogether. It was a genuine bump when it was added in 6ad15e2, but `org.apache:apache:39` — reached via `maven-plugins:49` → `maven-parent:49` — now manages **3.10.1**, so the local property had quietly turned into a downgrade. `mvn help:effective-pom` confirms the plugin resolves to 3.10.1 with the line gone.

Verified on `openjdk 26.0.2`: `mvn -Prun-its verify` goes from failing in the script interpreter to **Passed: 49, Failed: 0, Errors: 0, Skipped: 0**.

Generated-by: Claude Opus 5 (1M context)