### PR TITLE
Pin Maven prerequisite to 3.6.3 instead of ${mavenVersion}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ under the License.
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>


### PR DESCRIPTION
`${mavenVersion}` also sets the maven-core dependency version, so bumping that silently raises the declared baseline. Value is unchanged: still 3.6.3.

<sub>Drafted with Claude — please verify</sub>
