### PR TITLE
failsOnError should fail the build, not abort the report #656

### DIFF
--- a/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojo.java
@@ -56,6 +56,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.checkstyle.exec.CheckstyleExecutor;
 import org.apache.maven.plugins.checkstyle.exec.CheckstyleExecutorException;
 import org.apache.maven.plugins.checkstyle.exec.CheckstyleExecutorRequest;
+import org.apache.maven.plugins.checkstyle.exec.CheckstyleResults;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.FileUtils;
@@ -562,7 +563,10 @@ public class CheckstyleViolationCheckMojo extends AbstractMojo {
                         .setEncoding(inputEncoding)
                         .setPropertiesLocation(propertiesLocation)
                         .setOmitIgnoredModules(omitIgnoredModules);
-                checkstyleExecutor.executeCheckstyle(request);
+                CheckstyleResults results = checkstyleExecutor.executeCheckstyle(request);
+                if (results.getFailsOnErrorMessage() != null) {
+                    throw new MojoFailureException(results.getFailsOnErrorMessage());
+                }
 
             } catch (CheckstyleException e) {
                 throw new MojoExecutionException("Failed during checkstyle configuration", e);

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleResults.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/CheckstyleResults.java
@@ -38,6 +38,8 @@ public class CheckstyleResults {
 
     private Configuration configuration;
 
+    private String failsOnErrorMessage;
+
     public CheckstyleResults() {
         files = new HashMap<>();
     }
@@ -117,5 +119,13 @@ public class CheckstyleResults {
 
     public void setConfiguration(Configuration configuration) {
         this.configuration = configuration;
+    }
+
+    public String getFailsOnErrorMessage() {
+        return failsOnErrorMessage;
+    }
+
+    public void setFailsOnErrorMessage(String failsOnErrorMessage) {
+        this.failsOnErrorMessage = failsOnErrorMessage;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/checkstyle/exec/DefaultCheckstyleExecutor.java
@@ -195,6 +195,8 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
 
         checker.destroy();
 
+        CheckstyleResults results = checkerListener.getResults();
+
         if (nbErrors > 0) {
             StringBuilder message = new StringBuilder("There ");
             if (nbErrors == 1) {
@@ -219,16 +221,15 @@ public class DefaultCheckstyleExecutor implements CheckstyleExecutor {
             message.append(" ruleset.");
 
             if (request.isFailsOnError()) {
-                // TODO: should be a failure, not an error. Report is not meant to
-                // throw an exception here (so site would
-                // work regardless of config), but should record this information
-                throw new CheckstyleExecutorException(message.toString());
+                // Record rather than throw so the report goal can still generate
+                // the site. The check goal turns this into a MojoFailureException.
+                results.setFailsOnErrorMessage(message.toString());
             } else {
                 logger.info(message.toString());
             }
         }
 
-        return checkerListener.getResults();
+        return results;
     }
 
     protected void addSourceDirectory(

--- a/src/test/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/checkstyle/CheckstyleViolationCheckMojoTest.java
@@ -100,8 +100,8 @@ public class CheckstyleViolationCheckMojoTest {
             mojo.execute();
 
             fail("Must fail on violations");
-        } catch (MojoExecutionException e) {
-            // expected
+        } catch (MojoFailureException e) {
+            // expected: failsOnError is a build failure, not a plugin error
         }
     }
 


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

`failsOnError` used to throw `CheckstyleExecutorException` from `DefaultCheckstyleExecutor`. That is a plugin error, and it also stops the site report from rendering (the TODO on that throw).

The executor now records the message on `CheckstyleResults`. The check goal turns it into `MojoFailureException`. The report goal still generates the site.

`CheckstyleViolationCheckMojoTest.testPlainOutputFileFailOnError` now expects the failure, not an execution error.

Fixes #656
