### PR TITLE
Run the site ITs against the parent's site plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ under the License.
     <slf4jVersion>1.7.36</slf4jVersion>
     <doxiaVersion>2.1.0</doxiaVersion>
     <doxiaSitetoolsVersion>2.1.0</doxiaSitetoolsVersion>
-    <sitePluginVersion>3.20.0</sitePluginVersion>
+    <sitePluginVersion>${version.maven-site-plugin}</sitePluginVersion>
     <jxrPluginVersion>3.5.0</jxrPluginVersion>
     <project.build.outputTimestamp>2024-10-22T15:04:06Z</project.build.outputTimestamp>
   </properties>


### PR DESCRIPTION
`sitePluginVersion` is the filter token the integration tests substitute into their own POMs, so this
changes which site plugin the ITs exercise, not how this project's site is built. Every other
repository in the estate already takes it from `${version.maven-site-plugin}`; three still carry a
literal 3.20.0, which predates the anchor-generation change in 3.21.0/3.22.0.

The ASF parent currently resolves that to 3.22.0. If an IT asserts on generated anchors it will fail
here, and that failure is the point of the change.

*This change was created with AI assistance.*
